### PR TITLE
fix(deps): replace repo url with version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^11.3.0",
     "p-queue": "^6.6.2",
     "postcss": "^8.5.3",
-    "postcss-combine-duplicated-selectors": "poimen/postcss-combine-duplicated-selectors#duplicated-keyframes-fix",
+    "postcss-combine-duplicated-selectors": "^10.0.3",
     "postcss-combine-media-query": "^1.0.1",
     "postcss-discard-comments": "^7.0.3",
     "postcss-load-config": "^6.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^8.5.3
         version: 8.5.3
       postcss-combine-duplicated-selectors:
-        specifier: poimen/postcss-combine-duplicated-selectors#duplicated-keyframes-fix
-        version: https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/b993502206354b0d37b00995d334cb335b1254f9(postcss@8.5.3)
+        specifier: ^10.0.3
+        version: 10.0.3(postcss@8.5.3)
       postcss-combine-media-query:
         specifier: ^1.0.1
         version: 1.0.1
@@ -2200,10 +2200,9 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss-combine-duplicated-selectors@https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/b993502206354b0d37b00995d334cb335b1254f9:
-    resolution: {tarball: https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/b993502206354b0d37b00995d334cb335b1254f9}
-    version: 10.0.3
-    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
+  postcss-combine-duplicated-selectors@10.0.3:
+    resolution: {integrity: sha512-IP0BmwFloCskv7DV7xqvzDXqMHpwdczJa6ZvIW8abgHdcIHs9mCJX2ltFhu3EwA51ozp13DByng30+Ke+eIExA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >=14.0.0}
     peerDependencies:
       postcss: ^8.1.0
 
@@ -5084,7 +5083,7 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-combine-duplicated-selectors@https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/b993502206354b0d37b00995d334cb335b1254f9(postcss@8.5.3):
+  postcss-combine-duplicated-selectors@10.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild


### PR DESCRIPTION
Hello,

Attached is a PR where the branch reference of `stencil-tailwind-plugin` has been replaced with the version from the registry.

According to the repo, the customization has already been published, so it can be included with a version and no longer needs to reference the fork.

```bash
Progress: resolved 1339, reused 0, downloaded 476, added 470
Progress: resolved 1339, reused 0, downloaded 579, added 583
Progress: resolved 1339, reused 0, downloaded 669, added 672
Progress: resolved 1339, reused 0, downloaded 778, added 782
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: npm error code E401
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: npm error Unable to authenticate, your authentication token seems to be invalid.
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: npm error To correct this please try logging in again with:
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: npm error   npm login
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: npm error A complete log of this run can be found in: /home/vsts/.npm/_logs/2025-11-03T09_50_19_185Z-debug-0.log
...1969_b71f43a4d6b60ba2eb684cd366828aee npm-install: Failed
 ERR_PNPM_PREPARE_PACKAGE  Failed to prepare git-hosted package fetched from "[https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/bdf9223342b6b1da8a91d6727b6e4cf719f7def7"](https://codeload.github.com/poimen/postcss-combine-duplicated-selectors/tar.gz/bdf9223342b6b1da8a91d6727b6e4cf719f7def7%22): postcss-combine-duplicated-selectors@10.0.3 npm-install: `npm install`
Exit status 1
```

Thanks!