### PR TITLE
Add null check for cssNode in stylesheets processor

### DIFF
--- a/src/processors/stylesheets.ts
+++ b/src/processors/stylesheets.ts
@@ -29,6 +29,9 @@ async function transformStyleStatement(opts: PluginConfigurationOptions, sourceF
   };
 
   const cssNode = walkTo(sourceFile, stringLiteralPath);
+  if (!cssNode) {
+    return sourceText;
+  }
   await stringStyleRewriter(cssNode as StringLiteral);
 
   const printer = ts.createPrinter();


### PR DESCRIPTION
Add null check for cssNode to prevent errors.

potentially fixes #43

What the patch does

- Adds a defensive null check before rewriting style text inside the plugin transform.
- If no style node is found, the plugin returns the original source text instead of attempting to access a missing property.

In practice, this prevents the runtime error:

- Cannot read properties of undefined (reading text)