### PR TITLE
[codex] Fix package module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.5",
   "description": "This package is used to integrate [tailwindcss](https://tailwindcss.com/) and [StencilJS](https://stenciljs.com/). This plugin for Stencil is specifically focused on the integration between tailwindcss in [JIT](https://tailwindcss.com/docs/just-in-time-mode#enabling-jit-mode) mode and the Stencil build.",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
## Summary

This fixes the package ESM entry in `package.json`.

The published package currently points `module` at `dist/index.esm.js`, but the package/build output contains `dist/index.mjs` instead. ESM consumers and tooling that prefer the `module` field can therefore resolve a file that is not present in the package.

## Change

- Update `module` from `dist/index.esm.js` to `dist/index.mjs`.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `npm pack --dry-run --json`
- `node -e "const p=require('./package.json'); console.log(JSON.stringify({main:p.main,module:p.module}))"`
- `git diff --check`

I also ran `pnpm test`. It completed with 9/10 suites passing, 27/30 tests passing, and 33/36 snapshots passing. The remaining failures are three CSS snapshot diffs in `src/test/global-style/global-style.test.ts` showing output formatting/trailing-newline differences; I did not update snapshots because this PR only changes the package manifest entry.